### PR TITLE
Revamp dark theme with glass panels and chip buttons

### DIFF
--- a/Repo1_SLPR/index.html
+++ b/Repo1_SLPR/index.html
@@ -13,34 +13,34 @@
 </head>
 <body class="p-2 sm:p-4">
     <div id="header-container">
-        <header class="bg-slate-800/50 p-2 rounded-lg shadow-lg flex flex-col md:flex-row items-center justify-between gap-2">
+        <header class="glass-panel p-2 rounded-lg flex flex-col md:flex-row items-center justify-between gap-2">
             <div class="flex items-center gap-2 w-full md:w-auto">
-                <input type="text" id="usernameInput" placeholder="Sleeper Username" value="The_Oracle" class="w-full min-w-0 bg-slate-900 border-2 border-slate-700 focus:border-indigo-500 focus:ring-indigo-500 rounded-lg py-1 px-3 text-white placeholder-slate-500 transition-colors text-xs">
-                <button id="fetchRostersButton" class="bg-slate-400 hover:bg-slate-500 text-white font-bold py-1 px-3 text-xs rounded-lg transition-colors whitespace-nowrap">Rosters</button>
-                <button id="fetchOwnershipButton" class="bg-slate-700 hover:bg-slate-800 text-white font-bold py-1 px-3 text-xs rounded-lg transition-colors whitespace-nowrap border border-slate-500">Ownership %</button>
+                <input type="text" id="usernameInput" placeholder="Sleeper Username" value="The_Oracle" class="w-full min-w-0 placeholder-slate-500 text-xs">
+                <button id="fetchRostersButton" class="chip-btn text-xs whitespace-nowrap">Rosters</button>
+                <button id="fetchOwnershipButton" class="chip-btn text-xs whitespace-nowrap">Ownership %</button>
             </div>
             <div id="rosterControls" class="flex items-center gap-2 w-full md:w-auto">
                 <div class="flex items-center gap-1">
-                    <button id="compareButton" class="bg-pink-600 text-white font-bold py-1 px-3 text-xs rounded-lg whitespace-nowrap disabled:bg-slate-600 disabled:text-slate-400 disabled:cursor-not-allowed" disabled>Compare</button>
+                    <button id="compareButton" class="chip-btn text-xs whitespace-nowrap disabled:opacity-40 disabled:cursor-not-allowed" disabled>Compare</button>
                     <button id="clearCompareButton" class="text-xs text-slate-400 hover:text-white underline hidden">Clear</button>
                 </div>
-                <select id="leagueSelect" class="bg-slate-900 border-2 border-slate-700 rounded-lg py-1 px-3 text-white w-full text-xs" disabled>
+                <select id="leagueSelect" class="w-full text-xs" disabled>
                     <option>Select a league...</option>
                 </select>
                 <span id="formatIndicator" class="hidden"></span>
             </div>
         </header>
         <div id="view-controls" class="flex flex-nowrap justify-center items-center p-2 gap-1">
-             <div class="view-switcher flex p-0.5 bg-slate-800 rounded-lg">
-                <button id="positionalViewBtn" class="px-1.5 py-0.5 text-xs font-semibold rounded-md transition-colors">Positional</button>
-                <button id="depthChartViewBtn" class="px-1.5 py-0.5 text-xs font-semibold rounded-md transition-colors">Depth Chart</button>
+             <div class="view-switcher flex p-0.5 glass-panel rounded-lg">
+                <button id="positionalViewBtn" class="chip-btn text-xs font-semibold">Positional</button>
+                <button id="depthChartViewBtn" class="chip-btn text-xs font-semibold">Depth Chart</button>
             </div>
-            <div id="positional-filters" class="flex p-0.5 bg-slate-800 rounded-lg">
-                <button data-position="QB" class="filter-btn px-1.5 py-0.5 text-xs font-semibold rounded-md transition-colors">QB</button>
-                <button data-position="RB" class="filter-btn px-1.5 py-0.5 text-xs font-semibold rounded-md transition-colors">RB</button>
-                <button data-position="WR" class="filter-btn px-1.5 py-0.5 text-xs font-semibold rounded-md transition-colors">WR</button>
-                <button data-position="TE" class="filter-btn px-1.5 py-0.5 text-xs font-semibold rounded-md transition-colors">TE</button>
-                <button data-position="FLX" class="filter-btn px-1.5 py-0.5 text-xs font-semibold rounded-md transition-colors">FLX</button>
+            <div id="positional-filters" class="flex p-0.5 glass-panel rounded-lg">
+                <button data-position="QB" class="filter-btn chip-btn text-xs font-semibold">QB</button>
+                <button data-position="RB" class="filter-btn chip-btn text-xs font-semibold">RB</button>
+                <button data-position="WR" class="filter-btn chip-btn text-xs font-semibold">WR</button>
+                <button data-position="TE" class="filter-btn chip-btn text-xs font-semibold">TE</button>
+                <button data-position="FLX" class="filter-btn chip-btn text-xs font-semibold">FLX</button>
             </div>
         </div>
     </div>

--- a/Repo1_SLPR/script.js
+++ b/Repo1_SLPR/script.js
@@ -69,24 +69,8 @@
         }
 
         function updateButtonStates(activeButton) {
-            // --- Reset to Neutral States ---
-            // Rosters Button: slate-400 bg, white text
-            fetchRostersButton.classList.remove('bg-slate-300', 'text-slate-900');
-            fetchRostersButton.classList.add('bg-slate-400', 'text-white');
-
-            // Ownership Button: slate-700 bg
-            fetchOwnershipButton.classList.remove('bg-slate-600');
-            fetchOwnershipButton.classList.add('bg-slate-700');
-
-            // --- Apply Active State ---
-            if (activeButton === 'rosters') {
-                // Rosters active: slate-300 bg, slate-900 text
-                fetchRostersButton.classList.replace('bg-slate-400', 'bg-slate-300');
-                fetchRostersButton.classList.replace('text-white', 'text-slate-900');
-            } else if (activeButton === 'ownership') {
-                // Ownership active: slate-600 bg
-                fetchOwnershipButton.classList.replace('bg-slate-700', 'bg-slate-600');
-            }
+            fetchRostersButton.classList.toggle('active', activeButton === 'rosters');
+            fetchOwnershipButton.classList.toggle('active', activeButton === 'ownership');
         }
 
         async function handleFetchRosters() {

--- a/Repo1_SLPR/styles.css
+++ b/Repo1_SLPR/styles.css
@@ -1,38 +1,84 @@
-body {
-            font-family: 'Quicksand', sans-serif;
-            background-color: #010c20;
-            color: #e0e6ed;
+/* --- Theme Variables ----------------------------------------------------- */
+:root {
+            --bg-primary: #05080f;
+            --bg-secondary: #0f172a;
+            --glass-bg: rgba(255, 255, 255, 0.05);
+            --glass-border: rgba(255, 255, 255, 0.12);
+            --text-primary: #e0e6ed;
+            --accent: #685dfc;
+
+            --pos-qb: #ff2a6d;
+            --pos-rb: #00ceb8;
+            --pos-wr: #58a7ff;
+            --pos-te: #ffae58;
+            --pos-flx: #a855f7;
         }
-        
+
+        body {
+            font-family: 'Quicksand', sans-serif;
+            background-color: var(--bg-primary);
+            color: var(--text-primary);
+        }
+
         #header-container {
             position: sticky;
             top: 0;
             z-index: 10;
-            background-color: #010c20;
+            background-color: var(--bg-primary);
             padding-bottom: 0.2rem;
+        }
+
+        /* --- Utility Styles ------------------------------------------------ */
+        .glass-panel {
+            background: var(--glass-bg);
+            border: 1px solid var(--glass-border);
+            backdrop-filter: blur(8px);
+            -webkit-backdrop-filter: blur(8px);
+            box-shadow: 0 4px 12px rgba(0, 0, 0, 0.4);
+        }
+
+        .chip-btn {
+            background: var(--glass-bg);
+            border: 1px solid var(--glass-border);
+            border-radius: 9999px;
+            color: var(--text-primary);
+            font-weight: 600;
+            font-size: 0.75rem;
+            padding: 0.25rem 0.75rem;
+            transition: background 0.2s, box-shadow 0.2s;
+        }
+        .chip-btn:hover,
+        .chip-btn.active {
+            background: linear-gradient(135deg, var(--accent), var(--pos-flx));
+            box-shadow: 0 0 6px var(--accent);
+            color: #fff;
+        }
+        .chip-btn:disabled {
+            opacity: 0.4;
+            cursor: not-allowed;
         }
 
         /* --- Roster View Styles --- */
         #rosterContainer { width: 100%; overflow-x: auto; }
         #rosterGrid { display: flex; flex-direction: row; flex-wrap: nowrap; gap: 0.25rem; min-width: min-content; }
         .roster-column { width: 133.5px; flex-shrink: 0; }
-        .team-header-item { 
+        .team-header-item {
             display: flex;
             align-items: center;
             justify-content: center;
             gap: 0.3rem;
-            font-size: 0.7rem; 
-            font-weight: 700; 
-            color: #f4f7fb; 
-            text-align: center; 
-            padding: 0.1rem; 
-            background-color: #0f172a; 
-            border: 1px solid #214067; 
-            border-bottom: 1px solid #38455c; 
-            border-radius: 8px 8px 0 0; 
+            font-size: 0.7rem;
+            font-weight: 700;
+            color: #f4f7fb;
+            text-align: center;
+            padding: 0.1rem;
+            background-color: var(--bg-secondary);
+            border: 1px solid var(--glass-border);
+            border-bottom: 1px solid var(--glass-border);
+            border-radius: 8px 8px 0 0;
             cursor: pointer;
         }
-        .team-card { background-color: #0f172a; border: 1px solid #214067; border-top: none; border-radius: 0 0 8px 8px; padding: 0.25rem; display: flex; flex-direction: column; gap: 0.25rem; }
+        .team-card { background-color: var(--bg-secondary); border: 1px solid var(--glass-border); border-top: none; border-radius: 0 0 8px 8px; padding: 0.25rem; display: flex; flex-direction: column; gap: 0.25rem; }
         .roster-section h3 { font-size: 0.7rem; font-weight: 600; text-transform: uppercase; letter-spacing: .5px; margin-bottom: 0.2rem; padding-left: 4px; }
         .starters-section h3 { color: #91C7BF; }
         .bench-section h3 { color: #91A3C7; }
@@ -42,23 +88,23 @@ body {
         .rb-section h3 { color: #82e0ca; }
         .wr-section h3 { color: #a0c2f7; }
         .te-section h3 { color: #d1b3ff; }
-        .player-row, .pick-row { padding: 3px 2px; border-radius: 4px; cursor: default; }
+        .player-row, .pick-row { padding: 3px 2px; border-radius: 4px; cursor: default; background: var(--glass-bg); }
         .is-trade-mode .player-row, .is-trade-mode .pick-row { cursor: pointer; }
         .player-selected {
-            box-shadow: 0 0 0 2px #685dfc !important;
-            background-color: #2e287a !important;
+            box-shadow: 0 0 0 2px var(--accent) !important;
+            background-color: rgba(104, 93, 252, 0.25) !important;
         }
         .pick-row { display: flex; align-items: center; }
-        .roster-section .player-row:nth-child(odd), .roster-section .pick-row:nth-child(odd) { background-color: #111e35; }
-        .roster-section .player-row:nth-child(even), .roster-section .pick-row:nth-child(even) { background-color: #182842; }
-        .player-tag { flex-shrink: 0; width: 20px; height: 15px; border-radius: 3px; font-size: 9px; font-weight: 700; display: inline-flex; align-items: center; justify-content: center; color: #000000; text-transform: uppercase; }
+        .roster-section .player-row:nth-child(odd), .roster-section .pick-row:nth-child(odd) { background: rgba(255,255,255,0.04); }
+        .roster-section .player-row:nth-child(even), .roster-section .pick-row:nth-child(even) { background: rgba(255,255,255,0.07); }
+        .player-tag { flex-shrink: 0; width: 24px; height: 16px; border-radius: 4px; font-size: 9px; font-weight: 700; display: inline-flex; align-items: center; justify-content: center; color: #ffffff; text-transform: uppercase; }
         .player-info-wrapper { display: flex; flex-direction: column; flex-grow: 1; overflow: hidden; gap: 2px; }
         .player-name-line { display: flex; align-items: center; gap: 5px; }
         .player-name { font-weight: 700; font-size: 11px; color: #e7ecf2; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; flex-grow: 1; }
         .player-meta-line, .player-value-line { display: flex; align-items: center; gap: 5px; font-size: 10px; color: #8ca2c4; padding-left: 2px; }
         .player-meta-line > span, .player-meta-line > div, .player-value-line > span { font-weight: 600; }
         .player-meta-line .separator, .player-value-line .separator { color: #64748b; }
-        .team-tag { display: inline-flex; align-items: center; justify-content: center; padding: 0 3px; height: 13px; border-radius: 3px; font-size: 9px; line-height: 13px; font-weight: 700; background-color: #e8eaed; }
+        .team-tag { display: inline-flex; align-items: center; justify-content: center; padding: 0 3px; height: 13px; border-radius: 3px; font-size: 9px; line-height: 13px; font-weight: 700; background-color: #e8eaed; border: 1px solid rgba(255,255,255,0.4); color: #fff; }
         .player-value-line .value { font-weight: 700; font-size: 11px; }
         .pick-row { justify-content: space-between; }
         .pick-label { font-weight: 600; font-size: 11px; }
@@ -67,16 +113,16 @@ body {
 
         /* --- Player List View Styles --- */
         #playerListView { width: fit-content; margin: 0 auto; }
-        #playerSearch { background: #0f2141; border: 1px solid #214067; color: #e0e6ed; padding: 8px 12px; border-radius: 8px; font-size: 14px; width: 280px; max-width: 100%; margin: 1rem auto; display: block; }
+        #playerSearch { background: var(--glass-bg); border: 1px solid var(--glass-border); color: var(--text-primary); padding: 8px 12px; border-radius: 8px; font-size: 14px; width: 280px; max-width: 100%; margin: 1rem auto; display: block; backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px); }
         #playerSearch::placeholder { color: #9fb1cf; }
         .player-list-section { border-radius: 6px; overflow: hidden; }
-        .pl-player-row { display: flex; align-items: center; padding: 2px 6px; font-size: 12px; }
-        .player-list-section .pl-player-row:nth-child(odd) { background: #212635; }
-        .player-list-section .pl-player-row:nth-child(even) { background: #1e232d; }
+        .pl-player-row { display: flex; align-items: center; padding: 2px 6px; font-size: 12px; background: var(--glass-bg); }
+        .player-list-section .pl-player-row:nth-child(odd) { background: rgba(255,255,255,0.04); }
+        .player-list-section .pl-player-row:nth-child(even) { background: rgba(255,255,255,0.07); }
         .pl-player-info { display: flex; flex-direction: column; flex: 1; min-width: 0; }
         .pl-player-name { font-size: 12px; font-weight: 600; color: #e7ecf2; display: flex; align-items: center; }
         .pl-player-details { font-size: 10px; color: #8ca2c4; font-weight: 600; margin-top: 1px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
-        .pl-list-tag { min-width: 28px; height: 17px; line-height: 17px; font-size: 11px; font-weight: 600; text-align: center; border-radius: 3px; margin-right: 6px; color: #fff; flex: 0 0 auto; }
+        .pl-list-tag { min-width: 28px; height: 17px; line-height: 17px; font-size: 11px; font-weight: 600; text-align: center; border-radius: 4px; margin-right: 6px; color: #fff; flex: 0 0 auto; box-shadow: 0 0 4px rgba(0,0,0,0.4); }
         .pl-list-tag-spacer { width: 34px; height: 1px; flex: 0 0 auto; }
         .pl-right-meta {
             margin-left: 8px;
@@ -103,7 +149,25 @@ body {
         .pl-pct-low { color: #e5dbff; }
 
         /* --- General UI --- */
-        #loading, #welcome-screen { text-align: center; padding: 4rem 2rem; font-size: 1.2rem; color: #9fb1cf; background-color: #0f172a; border: 1px solid #214067; border-radius: 8px; }
+        #loading, #welcome-screen { text-align: center; padding: 4rem 2rem; font-size: 1.2rem; color: #9fb1cf; background: var(--glass-bg); border: 1px solid var(--glass-border); border-radius: 8px; backdrop-filter: blur(8px); -webkit-backdrop-filter: blur(8px); }
+
+        #usernameInput {
+            background: var(--glass-bg);
+            border: 1px solid var(--glass-border);
+            border-radius: 9999px;
+            padding: 0.25rem 0.75rem;
+            color: var(--text-primary);
+            font-size: 0.75rem;
+        }
+
+        #leagueSelect {
+            background: var(--glass-bg);
+            border: 1px solid var(--glass-border);
+            border-radius: 9999px;
+            padding: 0.25rem 0.75rem;
+            color: var(--text-primary);
+            font-size: 0.75rem;
+        }
         #welcome-screen h2 { font-size: 1.5rem; font-weight: 700; color: #f4f7fb; margin-bottom: 0.5rem; }
         #formatIndicator { font-size: 0.8rem; font-weight: 700; margin-left: 0.5rem; }
         .format-1qb { color: #58a7ff; }
@@ -138,27 +202,30 @@ body {
             transform: translate(-50%, -50%);
         }
         .view-switcher button.active {
-            background-color: #4f46e5;
-            color: white;
+            background: linear-gradient(135deg, var(--accent), var(--pos-flx));
+            box-shadow: 0 0 6px var(--accent);
+            color: #fff;
         }
        
         /* --- Positional Filter Styles --- */
         .filter-btn {
-            background-color: transparent;
-            border: none;
-            transition: background-color 0.2s, color 0.2s;
+            background: var(--glass-bg);
+            border: 1px solid var(--glass-border);
+            border-radius: 9999px;
+            transition: background 0.2s, color 0.2s, box-shadow 0.2s;
+            color: var(--text-primary);
         }
-        .filter-btn[data-position="QB"] { color: #ff2a6d; }
-        .filter-btn[data-position="RB"] { color: #00ceb8; }
-        .filter-btn[data-position="WR"] { color: #58a7ff; }
-        .filter-btn[data-position="TE"] { color: #ffae58; }
-        .filter-btn[data-position="FLX"] { color: #a855f7; }
-        
-        .filter-btn.active[data-position="QB"] { background-color: #ff2a6d; color: #010c20; }
-        .filter-btn.active[data-position="RB"] { background-color: #00ceb8; color: #010c20; }
-        .filter-btn.active[data-position="WR"] { background-color: #58a7ff; color: #010c20; }
-        .filter-btn.active[data-position="TE"] { background-color: #ffae58; color: #010c20; }
-        .filter-btn.active[data-position="FLX"] { background-color: #a855f7; color: #010c20; }
+        .filter-btn[data-position="QB"] { color: var(--pos-qb); }
+        .filter-btn[data-position="RB"] { color: var(--pos-rb); }
+        .filter-btn[data-position="WR"] { color: var(--pos-wr); }
+        .filter-btn[data-position="TE"] { color: var(--pos-te); }
+        .filter-btn[data-position="FLX"] { color: var(--pos-flx); }
+
+        .filter-btn.active[data-position="QB"] { background: linear-gradient(135deg, var(--pos-qb), #b50e4a); color: #010c20; box-shadow: 0 0 6px var(--pos-qb); }
+        .filter-btn.active[data-position="RB"] { background: linear-gradient(135deg, var(--pos-rb), #008578); color: #010c20; box-shadow: 0 0 6px var(--pos-rb); }
+        .filter-btn.active[data-position="WR"] { background: linear-gradient(135deg, var(--pos-wr), #386cbf); color: #010c20; box-shadow: 0 0 6px var(--pos-wr); }
+        .filter-btn.active[data-position="TE"] { background: linear-gradient(135deg, var(--pos-te), #d17f20); color: #010c20; box-shadow: 0 0 6px var(--pos-te); }
+        .filter-btn.active[data-position="FLX"] { background: linear-gradient(135deg, var(--pos-flx), #7c3aed); color: #010c20; box-shadow: 0 0 6px var(--pos-flx); }
 
         /* --- Trade Simulator Styles --- */
         #tradeSimulator {
@@ -166,22 +233,37 @@ body {
             bottom: 0;
             left: 0;
             right: 0;
-            background-color: #0f172a;
-            border-top: 2px solid #334155;
+            background: var(--glass-bg);
+            border-top: 2px solid var(--glass-border);
             padding: 0.25rem;
             z-index: 20;
             display: none;
             flex-direction: column;
             gap: 0.25rem;
             max-height: 33vh;
+            backdrop-filter: blur(8px);
+            -webkit-backdrop-filter: blur(8px);
         }
         .trade-header { display: flex; justify-content: space-between; align-items: center; padding: 0 0.25rem; }
         .trade-header h3 { font-size: 0.8rem; font-weight: 700; color: #cbd5e1; }
-        #clearTradeButton { background: #475569; color: white; font-size: 0.65rem; padding: 2px 6px; border-radius: 4px; }
+        #clearTradeButton {
+            background: var(--glass-bg);
+            border: 1px solid var(--glass-border);
+            border-radius: 9999px;
+            color: var(--text-primary);
+            font-size: 0.65rem;
+            padding: 2px 6px;
+            transition: background 0.2s, box-shadow 0.2s;
+        }
+        #clearTradeButton:hover {
+            background: linear-gradient(135deg, var(--accent), var(--pos-flx));
+            box-shadow: 0 0 6px var(--accent);
+            color: #fff;
+        }
         .trade-body { display: grid; grid-template-columns: 1fr 1fr; gap: 0.25rem; overflow-y: auto; }
-        .trade-team-column { background: #1e293b; border-radius: 6px; padding: 0.25rem; display: flex; flex-direction: column; }
+        .trade-team-column { background: var(--glass-bg); border-radius: 6px; padding: 0.25rem; display: flex; flex-direction: column; border: 1px solid var(--glass-border); }
         .trade-team-column h4 { font-size: 0.7rem; font-weight: 700; margin-bottom: 0.25rem; text-align: center; }
         .trade-assets { min-height: 20px; display: flex; flex-wrap: wrap; gap: 3px; align-content: flex-start; flex-grow: 1; }
-        .trade-asset-chip { background: #334155; font-size: 0.65rem; padding: 1px 4px; border-radius: 4px; display: flex; gap: 4px; align-items: center; }
+        .trade-asset-chip { background: var(--glass-bg); border: 1px solid var(--glass-border); font-size: 0.65rem; padding: 1px 6px; border-radius: 9999px; display: flex; gap: 4px; align-items: center; }
         .trade-asset-chip .ktc { font-weight: 700; }
         .trade-total { margin-top: 0.25rem; text-align: right; font-size: 0.75rem; font-weight: 700; }


### PR DESCRIPTION
## Summary
- Introduce CSS variables and glass-panel/ chip-button styling for a premium dark theme
- Restyle header, controls, and positional filters with frosted glass and gradient accent states
- Modernize trade simulator panel and asset chips with translucent surfaces

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_689ecc3516f8832e94f706894d4f207d