### PR TITLE
Refine roster header layout and show position ranks

### DIFF
--- a/JULES_SLPR/index.html
+++ b/JULES_SLPR/index.html
@@ -16,42 +16,47 @@
 <body class="p-2 sm:p-4">
     <div id="header-container">
         <header class="top-bar glass-panel">
-            <div class="username-area">
-                <input type="text" id="usernameInput" placeholder="Enter Sleeper Username..." value="The_Oracle">
+            <div class="top-row">
+                <div class="app-view-switcher">
+                    <button id="fetchRostersButton">Rosters</button>
+                    <button id="fetchOwnershipButton">Ownership %</button>
+                </div>
+                <div class="username-area">
+                    <input type="text" id="usernameInput" placeholder="Enter Sleeper Username..." value="The_Oracle">
+                </div>
             </div>
-            <div class="app-view-switcher">
-                <button id="fetchRostersButton">Rosters</button>
-                <button id="fetchOwnershipButton">Ownership %</button>
+
+            <div id="controls-container" class="hidden">
+                <div id="view-controls">
+                    <div id="rosterControls" class="control-row second-row">
+                        <div class="custom-select-wrapper">
+                            <select id="leagueSelect" disabled>
+                                <option>Select a league...</option>
+                            </select>
+                        </div>
+                        <span id="formatIndicator" class="hidden"></span>
+                        <div class="view-switcher">
+                            <button id="positionalViewBtn">Positional</button>
+                            <button id="depthChartViewBtn">Depth Chart</button>
+                        </div>
+                    </div>
+
+                    <div class="control-row third-row">
+                        <div class="compare-controls">
+                            <button id="compareButton" class="control-button" disabled>Compare</button>
+                            <button id="clearCompareButton" class="control-button-subtle hidden">Clear</button>
+                        </div>
+                        <div id="positional-filters">
+                            <button data-position="QB" class="filter-btn">QB</button>
+                            <button data-position="RB" class="filter-btn">RB</button>
+                            <button data-position="WR" class="filter-btn">WR</button>
+                            <button data-position="TE" class="filter-btn">TE</button>
+                            <button data-position="FLX" class="filter-btn">FLX</button>
+                        </div>
+                    </div>
+                </div>
             </div>
         </header>
-
-        <div id="controls-container" class="glass-panel hidden">
-             <div id="rosterControls">
-                <div class="custom-select-wrapper">
-                    <select id="leagueSelect" disabled>
-                        <option>Select a league...</option>
-                    </select>
-                </div>
-                <span id="formatIndicator" class="hidden"></span>
-                <div class="compare-controls">
-                    <button id="compareButton" class="control-button" disabled>Compare</button>
-                    <button id="clearCompareButton" class="control-button-subtle hidden">Clear</button>
-                </div>
-            </div>
-            <div id="view-controls">
-                <div class="view-switcher">
-                    <button id="positionalViewBtn">Positional</button>
-                    <button id="depthChartViewBtn">Depth Chart</button>
-                </div>
-                <div id="positional-filters">
-                    <button data-position="QB" class="filter-btn">QB</button>
-                    <button data-position="RB" class="filter-btn">RB</button>
-                    <button data-position="WR" class="filter-btn">WR</button>
-                    <button data-position="TE" class="filter-btn">TE</button>
-                    <button data-position="FLX" class="filter-btn">FLX</button>
-                </div>
-            </div>
-        </div>
     </div>
     <main id="content" class="container mx-auto">
         <div id="welcome-screen">

--- a/JULES_SLPR/script.js
+++ b/JULES_SLPR/script.js
@@ -16,7 +16,6 @@
         const clearCompareButton = document.getElementById('clearCompareButton');
         const positionalViewBtn = document.getElementById('positionalViewBtn');
         const depthChartViewBtn = document.getElementById('depthChartViewBtn');
-        const viewControls = document.getElementById('view-controls');
         const positionalFiltersContainer = document.getElementById('positional-filters');
         const tradeSimulator = document.getElementById('tradeSimulator');
         const mainContent = document.getElementById('content');
@@ -32,6 +31,7 @@
         const API_BASE = 'https://api.sleeper.app/v1';
         const GOOGLE_SHEET_ID = '1MDTf1IouUIrm4qabQT9E5T0FsJhQtmaX55P32XK5c_0';
         const TAG_COLORS = { QB:"var(--pos-qb)", RB:"var(--pos-rb)", WR:"var(--pos-wr)", TE:"var(--pos-te)", BN:"var(--pos-bn)", TX:"var(--pos-tx)", FLX: "var(--pos-flx)", SFLX: "var(--pos-sflx)" };
+        const POS_RANK_COLORS = { QB: '#FF7AB2', RB: '#bbf7e0', WR: '#A0C2F7', TE: '#ffae58' };
         const STARTER_ORDER = ['QB', 'RB', 'WR', 'TE', 'FLEX', 'SUPER_FLEX'];
         const TEAM_COLORS = { ARI:"#97233F", ATL:"#A71930", BAL:"#241773", BUF:"#00338D", CAR:"#0085CA", CHI:"#0B162A", CIN:"#FB4F14", CLE:"#311D00", DAL:"#003594", DEN:"#FB4F14", DET:"#0076B6", GB:"#203731", HOU:"#03202F", IND:"#002C5F", JAX:"#006778", KC:"#E31837", LAC:"#0080C6", LAR:"#003594", LV:"#A5ACAF", MIA:"#008E97", MIN:"#4F2683", NE:"#002244", NO:"#D3BC8D", NYG:"#0B2265", NYJ:"#125740", PHI:"#004C54", PIT:"#FFB612", SEA:"#69BE28", SF:"#B3995D", TB:"#D50A0A", TEN:"#4B92DB", WAS:"#5A1414", FA: "#64748b" };
         const LEAGUE_COLOR_PALETTE = ['#e8d28a', '#bfeee5', '#d9d0ff', '#cfe9ff', '#ffd6e7', '#d9ffcf', '#ffc7a8', '#a8d8ff', '#f2c8ff', '#c8ffde'];
@@ -56,7 +56,6 @@
             await Promise.all([ fetchSleeperPlayers(), fetchDataFromGoogleSheet() ]);
             setLoading(false);
             welcomeScreen.classList.remove('hidden');
-            viewControls.classList.add('hidden'); // Initially hide view controls
         });
 
         // --- View Toggling and Main Handlers ---
@@ -351,14 +350,15 @@
                 if (columns.length < 13) return;
                 const clean = (str) => str ? str.replace(/"/g, '').trim() : '';
                 const pos = clean(columns[2]);
+                const posRank = clean(columns[7]);
                 const sleeperId = clean(columns[12]);
                 const adp = parseFloat(clean(columns[11]));
                 const ktcValue = parseInt(clean(columns[6]), 10);
                 if (pos === 'RDP') {
                     const pickName = clean(columns[1]);
-                    if (pickName) dataMap[pickName] = { adp: null, ktc: ktcValue };
+                    if (pickName) dataMap[pickName] = { adp: null, ktc: ktcValue, posRank: posRank };
                 } else if (sleeperId && sleeperId !== 'NA') {
-                    dataMap[sleeperId] = { adp: isNaN(adp) ? null : adp, ktc: isNaN(ktcValue) ? null : ktcValue };
+                    dataMap[sleeperId] = { adp: isNaN(adp) ? null : adp, ktc: isNaN(ktcValue) ? null : ktcValue, posRank };
                 }
             });
             return dataMap;
@@ -443,7 +443,7 @@
             let displayName = `${player.first_name.charAt(0)}. ${lastName}`;
             if (displayName.length > 15) displayName = displayName.substring(0, 14) + '…';
 
-            return { id: playerId, name: displayName, pos: player.position || '?', age: player.age || '?', team: player.team || 'FA', adp: valueData?.adp || null, ktc: valueData?.ktc || null, slot };
+            return { id: playerId, name: displayName, pos: player.position || '?', posRank: valueData?.posRank || '', age: player.age || '?', team: player.team || 'FA', adp: valueData?.adp || null, ktc: valueData?.ktc || null, slot };
         }
 
         function getPickData(pick) {
@@ -634,17 +634,18 @@
             const ktc = player.ktc || '—';
             const slotAbbr = { 'SUPER_FLEX': 'SFLX', 'FLEX': 'FLX' };
             const displaySlot = state.currentRosterView === 'depth' ? (slotAbbr[player.slot] || player.slot) : player.pos;
-            const teamTagHTML = player.team && player.team !== 'FA' 
-                ? `<div class="team-tag" style="background-color: ${TEAM_COLORS[player.team] || '#64748b'}; color: white; text-shadow: 1px 1px 2px rgba(0,0,0,0.5);">${player.team}</div>` 
+            const teamTagHTML = player.team && player.team !== 'FA'
+                ? `<div class="team-tag" style="background-color: ${TEAM_COLORS[player.team] || '#64748b'}; color: white; text-shadow: 1px 1px 2px rgba(0,0,0,0.5);">${player.team}</div>`
                 : `<div class="team-tag" style="background-color: #64748b; color: white;">${player.team || 'FA'}</div>`;
+            const posRankColor = POS_RANK_COLORS[player.posRank.split('·')[0]] || 'var(--color-text-secondary)';
 
             row.innerHTML = `
                 <div class="player-main-line">
-                    <div class="player-name">${player.name}</div>
                     <div class="player-tag" style="background-color: ${TAG_COLORS[displaySlot] || 'var(--pos-bn)'};">${displaySlot}</div>
+                    <div class="player-name">${player.name}</div>
                 </div>
                 <div class="player-meta-line">
-                    <span class="player-pos">${player.pos}</span>
+                    <span class="player-pos-rank" style="color:${posRankColor};">${player.posRank}</span>
                     <span class="separator">•</span>
                     <span>Age: <span class="player-age">${player.age || '?'}</span></span>
                     <span class="separator">•</span>

--- a/JULES_SLPR/styles.css
+++ b/JULES_SLPR/styles.css
@@ -150,11 +150,19 @@ body {
 /* --- HEADER & CONTROLS --- */
 .top-bar {
     display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 0.75rem 1rem;
+    background: linear-gradient(135deg, rgba(22,24,43,0.8), rgba(22,24,43,0.6));
+    box-shadow: 0 4px 20px rgba(0,0,0,0.25), 0 0 10px var(--color-accent-primary-glow);
+}
+
+.top-row {
+    display: flex;
     flex-wrap: wrap;
     align-items: center;
     justify-content: space-between;
-    gap: 1rem;
-    padding: 0.75rem 1rem;
+    gap: 0.75rem;
 }
 
 .username-area {
@@ -206,25 +214,31 @@ body {
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
-    padding: 0.75rem 1rem;
-    margin-top: 0.5rem;
+    padding: 0;
     transition: all 0.3s ease;
 }
 #controls-container.hidden {
     display: none;
 }
 
-#rosterControls, #view-controls {
+.control-row {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
+    justify-content: space-between;
     gap: 0.75rem;
 }
-#rosterControls {
-    justify-content: space-between;
+
+.compare-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
 }
+
 #view-controls {
-     justify-content: center;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
 }
 
 /* Custom Select */
@@ -406,8 +420,8 @@ body {
 
 .player-main-line {
     display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
+    align-items: center;
+    gap: 0.4rem;
 }
 .player-name { 
     font-weight: 700; 
@@ -429,6 +443,9 @@ body {
     gap: 0.4rem;
     font-size: 0.75rem;
     color: var(--color-text-secondary);
+}
+.player-pos-rank {
+    font-weight: 700;
 }
 .team-tag {
     font-size: 0.7rem;


### PR DESCRIPTION
## Summary
- Redesign mobile header with stacked rows for navigation, league selection, and filters
- Display player position rank from Google Sheet with color-coded tags
- Improve glass aesthetic with gradients and reorganized player rows

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_689efd33f0c8832e98dac0798588590f