### PR TITLE
Revamp roster page header and show colored position ranks

### DIFF
--- a/JULES_SLPR/index.html
+++ b/JULES_SLPR/index.html
@@ -16,32 +16,30 @@
 <body class="p-2 sm:p-4">
     <div id="header-container">
         <header class="top-bar glass-panel">
-            <div class="username-area">
-                <input type="text" id="usernameInput" placeholder="Enter Sleeper Username..." value="The_Oracle">
-            </div>
+            <input type="text" id="usernameInput" placeholder="Enter Sleeper Username..." value="The_Oracle">
             <div class="app-view-switcher">
                 <button id="fetchRostersButton">Rosters</button>
                 <button id="fetchOwnershipButton">Ownership %</button>
             </div>
         </header>
 
-        <div id="controls-container" class="glass-panel hidden">
-             <div id="rosterControls">
+        <div id="controls-container" class="hidden">
+            <div class="control-row glass-panel">
                 <div class="custom-select-wrapper">
                     <select id="leagueSelect" disabled>
                         <option>Select a league...</option>
                     </select>
                 </div>
                 <span id="formatIndicator" class="hidden"></span>
-                <div class="compare-controls">
-                    <button id="compareButton" class="control-button" disabled>Compare</button>
-                    <button id="clearCompareButton" class="control-button-subtle hidden">Clear</button>
-                </div>
-            </div>
-            <div id="view-controls">
                 <div class="view-switcher">
                     <button id="positionalViewBtn">Positional</button>
                     <button id="depthChartViewBtn">Depth Chart</button>
+                </div>
+            </div>
+            <div class="control-row glass-panel">
+                <div class="compare-controls">
+                    <button id="compareButton" class="control-button" disabled>Compare</button>
+                    <button id="clearCompareButton" class="control-button-subtle hidden">Clear</button>
                 </div>
                 <div id="positional-filters">
                     <button data-position="QB" class="filter-btn">QB</button>

--- a/JULES_SLPR/script.js
+++ b/JULES_SLPR/script.js
@@ -4,7 +4,6 @@
         const fetchOwnershipButton = document.getElementById('fetchOwnershipButton');
         const leagueSelect = document.getElementById('leagueSelect');
         const controlsContainer = document.getElementById('controls-container');
-        const rosterControls = document.getElementById('rosterControls');
         const loadingIndicator = document.getElementById('loading');
         const welcomeScreen = document.getElementById('welcome-screen');
         const formatIndicator = document.getElementById('formatIndicator');
@@ -16,7 +15,6 @@
         const clearCompareButton = document.getElementById('clearCompareButton');
         const positionalViewBtn = document.getElementById('positionalViewBtn');
         const depthChartViewBtn = document.getElementById('depthChartViewBtn');
-        const viewControls = document.getElementById('view-controls');
         const positionalFiltersContainer = document.getElementById('positional-filters');
         const tradeSimulator = document.getElementById('tradeSimulator');
         const mainContent = document.getElementById('content');
@@ -32,6 +30,7 @@
         const API_BASE = 'https://api.sleeper.app/v1';
         const GOOGLE_SHEET_ID = '1MDTf1IouUIrm4qabQT9E5T0FsJhQtmaX55P32XK5c_0';
         const TAG_COLORS = { QB:"var(--pos-qb)", RB:"var(--pos-rb)", WR:"var(--pos-wr)", TE:"var(--pos-te)", BN:"var(--pos-bn)", TX:"var(--pos-tx)", FLX: "var(--pos-flx)", SFLX: "var(--pos-sflx)" };
+        const POS_RANK_COLORS = { QB: '#FF7AB2', RB: '#bbf7e0', WR: '#A0C2F7', TE: '#ffae58' };
         const STARTER_ORDER = ['QB', 'RB', 'WR', 'TE', 'FLEX', 'SUPER_FLEX'];
         const TEAM_COLORS = { ARI:"#97233F", ATL:"#A71930", BAL:"#241773", BUF:"#00338D", CAR:"#0085CA", CHI:"#0B162A", CIN:"#FB4F14", CLE:"#311D00", DAL:"#003594", DEN:"#FB4F14", DET:"#0076B6", GB:"#203731", HOU:"#03202F", IND:"#002C5F", JAX:"#006778", KC:"#E31837", LAC:"#0080C6", LAR:"#003594", LV:"#A5ACAF", MIA:"#008E97", MIN:"#4F2683", NE:"#002244", NO:"#D3BC8D", NYG:"#0B2265", NYJ:"#125740", PHI:"#004C54", PIT:"#FFB612", SEA:"#69BE28", SF:"#B3995D", TB:"#D50A0A", TEN:"#4B92DB", WAS:"#5A1414", FA: "#64748b" };
         const LEAGUE_COLOR_PALETTE = ['#e8d28a', '#bfeee5', '#d9d0ff', '#cfe9ff', '#ffd6e7', '#d9ffcf', '#ffc7a8', '#a8d8ff', '#f2c8ff', '#c8ffde'];
@@ -56,7 +55,6 @@
             await Promise.all([ fetchSleeperPlayers(), fetchDataFromGoogleSheet() ]);
             setLoading(false);
             welcomeScreen.classList.remove('hidden');
-            viewControls.classList.add('hidden'); // Initially hide view controls
         });
 
         // --- View Toggling and Main Handlers ---
@@ -351,6 +349,7 @@
                 if (columns.length < 13) return;
                 const clean = (str) => str ? str.replace(/"/g, '').trim() : '';
                 const pos = clean(columns[2]);
+                const posRank = clean(columns[7]);
                 const sleeperId = clean(columns[12]);
                 const adp = parseFloat(clean(columns[11]));
                 const ktcValue = parseInt(clean(columns[6]), 10);
@@ -358,7 +357,7 @@
                     const pickName = clean(columns[1]);
                     if (pickName) dataMap[pickName] = { adp: null, ktc: ktcValue };
                 } else if (sleeperId && sleeperId !== 'NA') {
-                    dataMap[sleeperId] = { adp: isNaN(adp) ? null : adp, ktc: isNaN(ktcValue) ? null : ktcValue };
+                    dataMap[sleeperId] = { adp: isNaN(adp) ? null : adp, ktc: isNaN(ktcValue) ? null : ktcValue, posRank };
                 }
             });
             return dataMap;
@@ -443,7 +442,7 @@
             let displayName = `${player.first_name.charAt(0)}. ${lastName}`;
             if (displayName.length > 15) displayName = displayName.substring(0, 14) + '…';
 
-            return { id: playerId, name: displayName, pos: player.position || '?', age: player.age || '?', team: player.team || 'FA', adp: valueData?.adp || null, ktc: valueData?.ktc || null, slot };
+            return { id: playerId, name: displayName, pos: player.position || '?', posRank: valueData?.posRank || null, age: player.age || '?', team: player.team || 'FA', adp: valueData?.adp || null, ktc: valueData?.ktc || null, slot };
         }
 
         function getPickData(pick) {
@@ -634,17 +633,20 @@
             const ktc = player.ktc || '—';
             const slotAbbr = { 'SUPER_FLEX': 'SFLX', 'FLEX': 'FLX' };
             const displaySlot = state.currentRosterView === 'depth' ? (slotAbbr[player.slot] || player.slot) : player.pos;
-            const teamTagHTML = player.team && player.team !== 'FA' 
-                ? `<div class="team-tag" style="background-color: ${TEAM_COLORS[player.team] || '#64748b'}; color: white; text-shadow: 1px 1px 2px rgba(0,0,0,0.5);">${player.team}</div>` 
+            const posRank = player.posRank || player.pos;
+            const posKey = posRank.split('·')[0];
+            const posColor = POS_RANK_COLORS[posKey] || 'var(--color-text-secondary)';
+            const teamTagHTML = player.team && player.team !== 'FA'
+                ? `<div class="team-tag" style="background-color: ${TEAM_COLORS[player.team] || '#64748b'}; color: white; text-shadow: 1px 1px 2px rgba(0,0,0,0.5);">${player.team}</div>`
                 : `<div class="team-tag" style="background-color: #64748b; color: white;">${player.team || 'FA'}</div>`;
 
             row.innerHTML = `
                 <div class="player-main-line">
-                    <div class="player-name">${player.name}</div>
                     <div class="player-tag" style="background-color: ${TAG_COLORS[displaySlot] || 'var(--pos-bn)'};">${displaySlot}</div>
+                    <div class="player-name">${player.name}</div>
                 </div>
                 <div class="player-meta-line">
-                    <span class="player-pos">${player.pos}</span>
+                    <span class="player-pos-rank" style="color:${posColor}">${posRank}</span>
                     <span class="separator">•</span>
                     <span>Age: <span class="player-age">${player.age || '?'}</span></span>
                     <span class="separator">•</span>

--- a/JULES_SLPR/styles.css
+++ b/JULES_SLPR/styles.css
@@ -93,16 +93,19 @@ body {
     z-index: 10;
     padding: 0.5rem 0;
     background: linear-gradient(180deg, var(--color-bg) 70%, transparent 100%);
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
 }
 
 /* --- UTILITY CLASSES --- */
 .glass-panel {
-    background: var(--color-panel-bg);
+    background: linear-gradient(135deg, rgba(255,255,255,0.08), rgba(255,255,255,0.02));
     border: 1px solid var(--color-panel-border);
     border-radius: var(--panel-border-radius);
     backdrop-filter: blur(12px);
     -webkit-backdrop-filter: blur(12px);
-    box-shadow: 0 4px 20px rgba(0,0,0,0.25);
+    box-shadow: 0 4px 20px rgba(0,0,0,0.25), 0 0 10px var(--color-accent-primary-glow);
 }
 
 /* --- DEFAULTS FOR TAILWIND --- */
@@ -153,12 +156,8 @@ body {
     flex-wrap: wrap;
     align-items: center;
     justify-content: space-between;
-    gap: 1rem;
+    gap: 0.5rem;
     padding: 0.75rem 1rem;
-}
-
-.username-area {
-    flex-grow: 1;
 }
 
 #usernameInput {
@@ -171,6 +170,7 @@ body {
     width: 100%;
     min-width: 200px;
     transition: all 0.2s ease;
+    flex: 1;
 }
 #usernameInput:focus {
     outline: none;
@@ -205,8 +205,7 @@ body {
 #controls-container {
     display: flex;
     flex-direction: column;
-    gap: 0.75rem;
-    padding: 0.75rem 1rem;
+    gap: 0.5rem;
     margin-top: 0.5rem;
     transition: all 0.3s ease;
 }
@@ -214,17 +213,13 @@ body {
     display: none;
 }
 
-#rosterControls, #view-controls {
+.control-row {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
-    gap: 0.75rem;
-}
-#rosterControls {
     justify-content: space-between;
-}
-#view-controls {
-     justify-content: center;
+    gap: 0.75rem;
+    padding: 0.5rem 1rem;
 }
 
 /* Custom Select */
@@ -312,14 +307,19 @@ body {
 .view-switcher button.active {
     color: var(--color-text-primary);
     background: var(--color-accent-primary);
+    box-shadow: 0 0 var(--glow-strength) var(--color-accent-primary-glow);
 }
 
 .filter-btn { color: var(--color-text-secondary); }
-.filter-btn.active[data-position="QB"] { background-color: var(--pos-qb); color: var(--color-bg); }
-.filter-btn.active[data-position="RB"] { background-color: var(--pos-rb); color: var(--color-bg); }
-.filter-btn.active[data-position="WR"] { background-color: var(--pos-wr); color: var(--color-bg); }
-.filter-btn.active[data-position="TE"] { background-color: var(--pos-te); color: var(--color-bg); }
-.filter-btn.active[data-position="FLX"] { background-color: var(--pos-flx); color: var(--color-bg); }
+.filter-btn.active {
+    color: var(--color-bg);
+    box-shadow: 0 0 var(--glow-strength) var(--color-accent-primary-glow);
+}
+.filter-btn.active[data-position="QB"] { background-color: var(--pos-qb); }
+.filter-btn.active[data-position="RB"] { background-color: var(--pos-rb); }
+.filter-btn.active[data-position="WR"] { background-color: var(--pos-wr); }
+.filter-btn.active[data-position="TE"] { background-color: var(--pos-te); }
+.filter-btn.active[data-position="FLX"] { background-color: var(--pos-flx); }
 
 /* --- ROSTER VIEW --- */
 #rosterContainer { 
@@ -406,8 +406,8 @@ body {
 
 .player-main-line {
     display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
+    align-items: center;
+    gap: 0.5rem;
 }
 .player-name { 
     font-weight: 700; 
@@ -429,6 +429,9 @@ body {
     gap: 0.4rem;
     font-size: 0.75rem;
     color: var(--color-text-secondary);
+}
+.player-pos-rank {
+    font-weight: 600;
 }
 .team-tag {
     font-size: 0.7rem;


### PR DESCRIPTION
## Summary
- Reorganize roster header into three frosted-glass rows for username/page toggle, league/view controls, and compare/filter actions
- Apply upgraded glass aesthetics and responsive control-row styling for a polished mobile experience
- Display color-coded position ranks from the Google Sheet with position tags left of player names

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689efd33f0c8832e98dac0798588590f