### PR TITLE
Refine mobile header and player position display

### DIFF
--- a/JULES_SLPR/index.html
+++ b/JULES_SLPR/index.html
@@ -16,42 +16,43 @@
 <body class="p-2 sm:p-4">
     <div id="header-container">
         <header class="top-bar glass-panel">
-            <div class="username-area">
+            <div class="header-row top-row">
                 <input type="text" id="usernameInput" placeholder="Enter Sleeper Username..." value="The_Oracle">
+                <div class="app-view-switcher">
+                    <button id="fetchRostersButton">Rosters</button>
+                    <button id="fetchOwnershipButton">Ownership %</button>
+                </div>
             </div>
-            <div class="app-view-switcher">
-                <button id="fetchRostersButton">Rosters</button>
-                <button id="fetchOwnershipButton">Ownership %</button>
+            <div id="controls-container" class="hidden">
+                <div class="header-row second-row">
+                    <div class="league-select-group">
+                        <div class="custom-select-wrapper">
+                            <select id="leagueSelect" disabled>
+                                <option>Select a league...</option>
+                            </select>
+                        </div>
+                        <span id="formatIndicator" class="hidden"></span>
+                    </div>
+                    <div class="view-switcher">
+                        <button id="positionalViewBtn">Positional</button>
+                        <button id="depthChartViewBtn">Depth Chart</button>
+                    </div>
+                </div>
+                <div class="header-row third-row">
+                    <div class="compare-controls">
+                        <button id="compareButton" class="control-button" disabled>Compare</button>
+                        <button id="clearCompareButton" class="control-button-subtle hidden">Clear</button>
+                    </div>
+                    <div id="positional-filters">
+                        <button data-position="QB" class="filter-btn">QB</button>
+                        <button data-position="RB" class="filter-btn">RB</button>
+                        <button data-position="WR" class="filter-btn">WR</button>
+                        <button data-position="TE" class="filter-btn">TE</button>
+                        <button data-position="FLX" class="filter-btn">FLX</button>
+                    </div>
+                </div>
             </div>
         </header>
-
-        <div id="controls-container" class="glass-panel hidden">
-             <div id="rosterControls">
-                <div class="custom-select-wrapper">
-                    <select id="leagueSelect" disabled>
-                        <option>Select a league...</option>
-                    </select>
-                </div>
-                <span id="formatIndicator" class="hidden"></span>
-                <div class="compare-controls">
-                    <button id="compareButton" class="control-button" disabled>Compare</button>
-                    <button id="clearCompareButton" class="control-button-subtle hidden">Clear</button>
-                </div>
-            </div>
-            <div id="view-controls">
-                <div class="view-switcher">
-                    <button id="positionalViewBtn">Positional</button>
-                    <button id="depthChartViewBtn">Depth Chart</button>
-                </div>
-                <div id="positional-filters">
-                    <button data-position="QB" class="filter-btn">QB</button>
-                    <button data-position="RB" class="filter-btn">RB</button>
-                    <button data-position="WR" class="filter-btn">WR</button>
-                    <button data-position="TE" class="filter-btn">TE</button>
-                    <button data-position="FLX" class="filter-btn">FLX</button>
-                </div>
-            </div>
-        </div>
     </div>
     <main id="content" class="container mx-auto">
         <div id="welcome-screen">

--- a/JULES_SLPR/script.js
+++ b/JULES_SLPR/script.js
@@ -4,7 +4,6 @@
         const fetchOwnershipButton = document.getElementById('fetchOwnershipButton');
         const leagueSelect = document.getElementById('leagueSelect');
         const controlsContainer = document.getElementById('controls-container');
-        const rosterControls = document.getElementById('rosterControls');
         const loadingIndicator = document.getElementById('loading');
         const welcomeScreen = document.getElementById('welcome-screen');
         const formatIndicator = document.getElementById('formatIndicator');
@@ -16,7 +15,6 @@
         const clearCompareButton = document.getElementById('clearCompareButton');
         const positionalViewBtn = document.getElementById('positionalViewBtn');
         const depthChartViewBtn = document.getElementById('depthChartViewBtn');
-        const viewControls = document.getElementById('view-controls');
         const positionalFiltersContainer = document.getElementById('positional-filters');
         const tradeSimulator = document.getElementById('tradeSimulator');
         const mainContent = document.getElementById('content');
@@ -32,6 +30,7 @@
         const API_BASE = 'https://api.sleeper.app/v1';
         const GOOGLE_SHEET_ID = '1MDTf1IouUIrm4qabQT9E5T0FsJhQtmaX55P32XK5c_0';
         const TAG_COLORS = { QB:"var(--pos-qb)", RB:"var(--pos-rb)", WR:"var(--pos-wr)", TE:"var(--pos-te)", BN:"var(--pos-bn)", TX:"var(--pos-tx)", FLX: "var(--pos-flx)", SFLX: "var(--pos-sflx)" };
+        const POS_RK_COLORS = { QB: '#FF7AB2', RB: '#bbf7e0', WR: '#A0C2F7', TE: '#ffae58' };
         const STARTER_ORDER = ['QB', 'RB', 'WR', 'TE', 'FLEX', 'SUPER_FLEX'];
         const TEAM_COLORS = { ARI:"#97233F", ATL:"#A71930", BAL:"#241773", BUF:"#00338D", CAR:"#0085CA", CHI:"#0B162A", CIN:"#FB4F14", CLE:"#311D00", DAL:"#003594", DEN:"#FB4F14", DET:"#0076B6", GB:"#203731", HOU:"#03202F", IND:"#002C5F", JAX:"#006778", KC:"#E31837", LAC:"#0080C6", LAR:"#003594", LV:"#A5ACAF", MIA:"#008E97", MIN:"#4F2683", NE:"#002244", NO:"#D3BC8D", NYG:"#0B2265", NYJ:"#125740", PHI:"#004C54", PIT:"#FFB612", SEA:"#69BE28", SF:"#B3995D", TB:"#D50A0A", TEN:"#4B92DB", WAS:"#5A1414", FA: "#64748b" };
         const LEAGUE_COLOR_PALETTE = ['#e8d28a', '#bfeee5', '#d9d0ff', '#cfe9ff', '#ffd6e7', '#d9ffcf', '#ffc7a8', '#a8d8ff', '#f2c8ff', '#c8ffde'];
@@ -56,7 +55,6 @@
             await Promise.all([ fetchSleeperPlayers(), fetchDataFromGoogleSheet() ]);
             setLoading(false);
             welcomeScreen.classList.remove('hidden');
-            viewControls.classList.add('hidden'); // Initially hide view controls
         });
 
         // --- View Toggling and Main Handlers ---
@@ -345,20 +343,30 @@
 
         function parseSheetData(csvText) {
             const dataMap = {};
-            const lines = csvText.split(/\r?\n/).slice(1);
-            lines.forEach(line => {
+            const lines = csvText.split(/\r?\n/);
+            if (lines.length < 2) return dataMap;
+            const header = lines[0].match(/(".*?"|[^",]+)(?=\s*,|\s*$)/g) || [];
+            const clean = (str) => str ? str.replace(/"/g, '').trim() : '';
+            const idx = {
+                pos: header.findIndex(h => clean(h) === 'POS'),
+                posrk: header.findIndex(h => clean(h) === 'POS·RK'),
+                sleeper: header.findIndex(h => clean(h).toUpperCase() === 'ID'),
+                adp: header.findIndex(h => clean(h).toUpperCase() === 'ADP'),
+                ktc: header.findIndex(h => clean(h).toUpperCase() === 'KTC')
+            };
+            lines.slice(1).forEach(line => {
                 const columns = line.match(/(".*?"|[^",]+)(?=\s*,|\s*$)/g) || [];
-                if (columns.length < 13) return;
-                const clean = (str) => str ? str.replace(/"/g, '').trim() : '';
-                const pos = clean(columns[2]);
-                const sleeperId = clean(columns[12]);
-                const adp = parseFloat(clean(columns[11]));
-                const ktcValue = parseInt(clean(columns[6]), 10);
+                if (columns.length <= Math.max(idx.pos, idx.posrk, idx.sleeper, idx.adp, idx.ktc)) return;
+                const pos = clean(columns[idx.pos]);
+                const sleeperId = clean(columns[idx.sleeper]);
+                const adp = parseFloat(clean(columns[idx.adp]));
+                const ktcValue = parseInt(clean(columns[idx.ktc]), 10);
+                const posrk = clean(columns[idx.posrk]);
                 if (pos === 'RDP') {
                     const pickName = clean(columns[1]);
                     if (pickName) dataMap[pickName] = { adp: null, ktc: ktcValue };
                 } else if (sleeperId && sleeperId !== 'NA') {
-                    dataMap[sleeperId] = { adp: isNaN(adp) ? null : adp, ktc: isNaN(ktcValue) ? null : ktcValue };
+                    dataMap[sleeperId] = { adp: isNaN(adp) ? null : adp, ktc: isNaN(ktcValue) ? null : ktcValue, posrk };
                 }
             });
             return dataMap;
@@ -443,7 +451,7 @@
             let displayName = `${player.first_name.charAt(0)}. ${lastName}`;
             if (displayName.length > 15) displayName = displayName.substring(0, 14) + '…';
 
-            return { id: playerId, name: displayName, pos: player.position || '?', age: player.age || '?', team: player.team || 'FA', adp: valueData?.adp || null, ktc: valueData?.ktc || null, slot };
+            return { id: playerId, name: displayName, pos: player.position || '?', age: player.age || '?', team: player.team || 'FA', adp: valueData?.adp || null, ktc: valueData?.ktc || null, posrk: valueData?.posrk || null, slot };
         }
 
         function getPickData(pick) {
@@ -634,17 +642,20 @@
             const ktc = player.ktc || '—';
             const slotAbbr = { 'SUPER_FLEX': 'SFLX', 'FLEX': 'FLX' };
             const displaySlot = state.currentRosterView === 'depth' ? (slotAbbr[player.slot] || player.slot) : player.pos;
-            const teamTagHTML = player.team && player.team !== 'FA' 
-                ? `<div class="team-tag" style="background-color: ${TEAM_COLORS[player.team] || '#64748b'}; color: white; text-shadow: 1px 1px 2px rgba(0,0,0,0.5);">${player.team}</div>` 
+            const teamTagHTML = player.team && player.team !== 'FA'
+                ? `<div class="team-tag" style="background-color: ${TEAM_COLORS[player.team] || '#64748b'}; color: white; text-shadow: 1px 1px 2px rgba(0,0,0,0.5);">${player.team}</div>`
                 : `<div class="team-tag" style="background-color: #64748b; color: white;">${player.team || 'FA'}</div>`;
+            const posRankText = player.posrk || player.pos;
+            const posKey = posRankText.split('·')[0];
+            const posRankColor = POS_RK_COLORS[posKey] || 'var(--color-text-secondary)';
 
             row.innerHTML = `
                 <div class="player-main-line">
-                    <div class="player-name">${player.name}</div>
                     <div class="player-tag" style="background-color: ${TAG_COLORS[displaySlot] || 'var(--pos-bn)'};">${displaySlot}</div>
+                    <div class="player-name">${player.name}</div>
                 </div>
                 <div class="player-meta-line">
-                    <span class="player-pos">${player.pos}</span>
+                    <span class="player-posrk" style="color:${posRankColor}">${posRankText}</span>
                     <span class="separator">•</span>
                     <span>Age: <span class="player-age">${player.age || '?'}</span></span>
                     <span class="separator">•</span>

--- a/JULES_SLPR/styles.css
+++ b/JULES_SLPR/styles.css
@@ -158,33 +158,52 @@ body {
     box-shadow: 0 4px 20px rgba(0,0,0,0.25), 0 0 15px rgba(118,109,255,0.2);
 }
 
+
 .header-row {
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     align-items: center;
     justify-content: space-between;
-    gap: 0.75rem;
+    gap: 0.5rem;
 }
 
 .header-row .custom-select-wrapper {
-    flex: 1;
+    flex: 1 1 auto;
+    max-width: 55%;
 }
 
 .top-row #usernameInput {
-    flex: 1;
+    flex: 1 1 auto;
+    max-width: 55%;
 }
 
 .league-select-group {
     display: flex;
     align-items: center;
     gap: 0.5rem;
-    flex: 1;
+    flex: 1 1 auto;
+    max-width: 55%;
 }
 
 .compare-controls {
     display: flex;
     align-items: center;
     gap: 0.5rem;
+    flex: 0 0 auto;
+}
+
+.view-switcher,
+.app-view-switcher {
+    flex: 0 0 auto;
+}
+
+.third-row #positional-filters {
+    flex: 1 1 auto;
+    overflow-x: auto;
+}
+
+#positional-filters::-webkit-scrollbar {
+    display: none;
 }
 
 #usernameInput {
@@ -207,8 +226,10 @@ body {
 .app-view-switcher {
     display: flex;
     background: var(--color-bg-light);
+    border: 1px solid var(--color-panel-border);
     border-radius: 8px;
     padding: 0.25rem;
+    box-shadow: 0 0 10px rgba(66,194,255,0.15);
 }
 .app-view-switcher button {
     padding: 0.4rem 0.75rem;
@@ -221,11 +242,12 @@ body {
     cursor: pointer;
     transition: all 0.2s ease;
     white-space: nowrap;
+    flex: 0 0 auto;
 }
 .app-view-switcher button.active {
-    color: var(--color-text-primary);
-    background: var(--color-accent-primary);
-    box-shadow: 0 0 var(--glow-strength) var(--color-accent-primary-glow);
+    color: var(--color-bg);
+    background: var(--color-accent-secondary);
+    box-shadow: 0 0 var(--glow-strength) rgba(66,194,255,0.5);
 }
 
 #controls-container {
@@ -307,9 +329,11 @@ body {
 .view-switcher, #positional-filters {
     display: flex;
     background: var(--color-bg-light);
+    border: 1px solid var(--color-panel-border);
     border-radius: 8px;
     padding: 0.25rem;
     gap: 0.25rem;
+    box-shadow: 0 0 10px rgba(118,109,255,0.15);
 }
 .view-switcher button, .filter-btn {
     padding: 0.4rem 0.75rem;
@@ -321,9 +345,10 @@ body {
     cursor: pointer;
     transition: all 0.2s ease;
     white-space: nowrap;
+    flex: 0 0 auto;
 }
 .view-switcher button.active {
-    color: var(--color-text-primary);
+    color: var(--color-bg);
     background: var(--color-accent-primary);
     box-shadow: 0 0 var(--glow-strength) var(--color-accent-primary-glow);
 }
@@ -349,9 +374,9 @@ body {
     min-width: min-content; 
     padding-bottom: 1rem; /* For scrollbar clearance */
 }
-.roster-column { 
-    width: 150px; 
-    flex-shrink: 0; 
+.roster-column {
+    width: 165px;
+    flex-shrink: 0;
     display: flex;
     flex-direction: column;
     gap: 0.5rem;

--- a/JULES_SLPR/styles.css
+++ b/JULES_SLPR/styles.css
@@ -148,17 +148,43 @@ body {
 }
 
 /* --- HEADER & CONTROLS --- */
+
 .top-bar {
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    padding: 1rem;
+    background: linear-gradient(135deg, rgba(22,24,43,0.7), rgba(22,24,43,0.4));
+    box-shadow: 0 4px 20px rgba(0,0,0,0.25), 0 0 15px rgba(118,109,255,0.2);
+}
+
+.header-row {
     display: flex;
     flex-wrap: wrap;
     align-items: center;
     justify-content: space-between;
-    gap: 1rem;
-    padding: 0.75rem 1rem;
+    gap: 0.75rem;
 }
 
-.username-area {
-    flex-grow: 1;
+.header-row .custom-select-wrapper {
+    flex: 1;
+}
+
+.top-row #usernameInput {
+    flex: 1;
+}
+
+.league-select-group {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    flex: 1;
+}
+
+.compare-controls {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
 }
 
 #usernameInput {
@@ -168,8 +194,8 @@ body {
     color: var(--color-text-primary);
     padding: 0.5rem 0.75rem;
     font-size: 0.9rem;
-    width: 100%;
-    min-width: 200px;
+    width: auto;
+    min-width: 0;
     transition: all 0.2s ease;
 }
 #usernameInput:focus {
@@ -212,19 +238,6 @@ body {
 }
 #controls-container.hidden {
     display: none;
-}
-
-#rosterControls, #view-controls {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.75rem;
-}
-#rosterControls {
-    justify-content: space-between;
-}
-#view-controls {
-     justify-content: center;
 }
 
 /* Custom Select */
@@ -312,6 +325,7 @@ body {
 .view-switcher button.active {
     color: var(--color-text-primary);
     background: var(--color-accent-primary);
+    box-shadow: 0 0 var(--glow-strength) var(--color-accent-primary-glow);
 }
 
 .filter-btn { color: var(--color-text-secondary); }
@@ -406,8 +420,8 @@ body {
 
 .player-main-line {
     display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
+    align-items: center;
+    gap: 0.4rem;
 }
 .player-name { 
     font-weight: 700; 
@@ -421,6 +435,10 @@ body {
     padding: 2px 6px;
     border-radius: 5px;
     color: var(--color-bg);
+}
+
+.player-posrk {
+    font-weight: 700;
 }
 
 .player-meta-line {


### PR DESCRIPTION
## Summary
- Restructure roster/ownership header into stacked rows for username, league selection and compare filters.
- Parse positional rank from the Google Sheet and surface it alongside player age and team with color coding.
- Apply polished mobile styles: frosted-glass header, inline position tags and improved filter controls.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689efd33f0c8832e98dac0798588590f